### PR TITLE
executes callback after the digest cycle is completed

### DIFF
--- a/directives/inline-edit/README.md
+++ b/directives/inline-edit/README.md
@@ -53,4 +53,4 @@ IMPORTANT: in `options-expression` - x as x for x in options - that last bit `op
 
 ## Change Log 2/24/2016
 
-* Inline-edit now takes an option attribute, `save-callback`, to which you can attach a callback function for when the save button gets pressed.
+* Inline-edit now takes an option attribute, `on-save`, to which you can attach a callback function for when the save button gets pressed.

--- a/directives/inline-edit/inline-edit.js
+++ b/directives/inline-edit/inline-edit.js
@@ -1,5 +1,5 @@
 angular.module('cui-ng')
-.directive('inlineEdit', ['$compile', function($compile){
+.directive('inlineEdit', ['$compile', '$timeout', function($compile, $timeout){
   return {
     restrict: 'E',
     scope:{
@@ -8,7 +8,7 @@ angular.module('cui-ng')
       options: '=',
       display: '=',
       localData: '=',
-      saveCallback: '='
+      saveCallback: '&onSave'
     },
     link: function(scope,ele,attrs){
       scope.edit=false;
@@ -21,7 +21,11 @@ angular.module('cui-ng')
       };
       scope.saveInput=function(){
         scope.model=scope.editInput;
-        if(scope.saveCallback) scope.saveCallback();
+        if(scope.saveCallback) {
+          $timeout(function() {
+            scope.saveCallback();
+          });
+        } 
         getDisplayValue();
       };
       scope.parseKeyCode=function(e){


### PR DESCRIPTION
Testing the new `save-callback` feature, we realized that the callback function was executed before the scope was updated.
Also we found out in the Angular guides that the value `&` is suggested for callbacks. 
